### PR TITLE
bigram-driven spawned one-way perigram readers

### DIFF
--- a/src/oneway-perigram-reader.js
+++ b/src/oneway-perigram-reader.js
@@ -13,14 +13,18 @@ function OnewayPerigramReader(g, rx, ry, speed, dir, parent) {
   this.type = 'OnewayPerigramReader';
 
   this.wayToGo = dir;
-  this.altWayToGo = (dir == 2) ? 1 : 7; // allowing N or S for NE or SE
+  // allow N if dir is NE, or S if dir is SE:
+  this.altWayToGo = (dir == 2) ? 1 : 7;
   this.parentLast = parent;
   this.selectedLast = null;
   this.consoleString = '';
   this.currentKey = '';
   this.phrase = '';
   this.freeCount = 0;
-  this.maxFreeCount = 5;
+  // if maxFreeCount is 0, no non-bigram moves allowed
+  this.maxFreeCount = 0;
+  // adjust for bigram count threshold:
+  this.bigramThreshold = 0;
   this.neighbors = [];
   this.darkThemeFade = colorToObject(191, 191, 191, 255);
   this.lightThemeFade = colorToObject(63, 63, 63, 255);
@@ -74,7 +78,7 @@ OnewayPerigramReader.prototype._determineReadingPath = function (last, neighbors
   var nextCell = this._chooseCell(vectorNeighbors);
 
   if (nextCell) {
-  	// info("Found bigram"); // DEBUG
+  	// info("Found " + this.current.text() + "+" + nextCell.text() + ": " + this.pman.bigramCount([this.current,nextCell])); // DEBUG
   	this.freeCount = 0;
   }
 
@@ -108,7 +112,7 @@ OnewayPerigramReader.prototype._isViableDirection = function (curr, neighbor) {
 
   if (!curr || !neighbor) return false;
 
-  return this.pman.isBigram([curr, neighbor]);
+  return this.pman.isBigram([curr, neighbor], this.bigramThreshold);
 }
 
 //////////////////////// Exports ////////////////////////

--- a/src/spawning-perigram-reader.js
+++ b/src/spawning-perigram-reader.js
@@ -31,8 +31,10 @@ SpawningPerigramReader.prototype.selectNext = function () {
 
   var last = this.lastRead(2),
     neighbors = Grid.gridFor(this.current).neighborhood(this.current);
+  var selected = this._determineReadingPath(last, neighbors);
+  // info("bigram count of " + this.current.text() + "+" + selected.text() + ": " + this.pman.bigramCount([this.current, selected]));
 
-  return this._determineReadingPath(last, neighbors);
+  return selected; // DEBUGGING this._determineReadingPath(last, neighbors);
 }
 
 SpawningPerigramReader.prototype._determineReadingPath = function (last, neighbors) {


### PR DESCRIPTION
@dhowe OK: you probably want check this out and solo one or other of the spawners and see how their visuals look to you.

They are now implemented as one-way perigrammers that are allowed to go either 1) NE & N or 2) SE & S. Their bigram threshold is 0 (i.e. a bigram of any count will do). Despite this, they die pretty quick now, but at least they are using the data properly. (NB: it is a viable NE or SE trigram-perigram that spawns them after which they proceed using the bigram data.) Whereas:

They used to live longer because (perforce) I allowed them a maximum of 5 'free' (non-viable, non-bigram) steps. So: Is this pretty enough for us?